### PR TITLE
Object.create and ;'s 

### DIFF
--- a/lib/character.js
+++ b/lib/character.js
@@ -1,10 +1,12 @@
-var util = require('util'),
-    Entity = require('./entity');
+var Entity = require('./entity')
 
-module.exports = Character;
-util.inherits(Character, Entity);
+module.exports = Character
 function Character() {
-    Character.super_.apply(this);
-    this.hp = 100;
-    this.inventory = {};
+  Entity.call(this)
 }
+
+Character.prototype = Object.create(Entity.prototype, {
+  name: { value: '' },
+  hp: { value: 100 },
+  inventory: { value: {} }
+})

--- a/lib/entity.js
+++ b/lib/entity.js
@@ -1,14 +1,13 @@
 var uuid = require('node-uuid');
 
 module.exports = Entity;
-function Entity() {}
-
-Entity.prototype.create = function () {
-    this.id = uuid.v4();
-    this.x = 0;
-    this.y = 0;
-    return this;
+function Entity() {
+    this.id = uuid.v4()
+    this.x = 0
+    this.y = 0
 }
 
-Entity.prototype.getPosition = function () { return [this.x, this.y]; };
-Entity.prototype.setPosition = function (x, y) { this.x = x; this.y = y; };
+Entity.prototype = {
+  getPosition: function () { return [this.x, this.y] },
+  setPosition: function (x, y) { this.x = x; this.y = y; }
+}

--- a/lib/god.js
+++ b/lib/god.js
@@ -1,20 +1,30 @@
-var EE = require('events').EventEmitter,
-    util = require('util'),
-    Character = require('./character'),
-    Item = require('./item');
+var EE = require('events').EventEmitter
+  , Character = require('./character')
+  , Item = require('./item')
 
-util.inherits(God, EE);
+function God() {}
+
+function create(type, o) {
+  o = o || {};
+  var creation = new this[type]()
+
+  // this should probably just be created. type can be checked in the payload.
+  this.emit(type+':created', creation); // let the world know about my creations
+  return creation;
+}
+
+God.prototype = Object.create(EE.prototype, {
+  create: {
+    value: create
+  },
+    
+  character: {
+    value: Character
+  },
+
+  item: {
+    value: Item
+  }
+})
+
 module.exports = new God();
-function God() {
-    this.character = new Character();
-    this.item = new Item();
-}
-
-God.prototype.create = function (type, o) {
-    o = o || {};
-    var creation = this[type].create(o);
-
-    // this should probably just be created. type can be checked in the payload.
-    this.emit(type+':created', creation); // let the world know about my creations
-    return creation;
-}

--- a/lib/item.js
+++ b/lib/item.js
@@ -1,10 +1,10 @@
-var util = require('util'),
-    Entity = require('./entity');
+var Entity = require('./entity')
 
-module.exports = Item;
-util.inherits(Item, Entity);
+module.exports = Item
 function Item() {
-    Item.super_.apply(this);
-    this.hp = 100;
-    return this;
+  Entity.call(this)
 }
+
+Item.prototype = Object.create(Entity.prototype, {
+  hp: { value: 50 }
+})


### PR DESCRIPTION
Using `Object.create` in places and removing ;'s. I left `new` around when we need to climb the constructor chain. 
